### PR TITLE
Skip singles as defined by the Spotify API `album.album_type` data

### DIFF
--- a/spotify_new_albums_release_radar.rb
+++ b/spotify_new_albums_release_radar.rb
@@ -26,8 +26,7 @@ release_radar.tracks.each do |track|
 
   artist = track.artists.first
 
-  # Let's assume albums with only one track are singles
-  next if track.album.tracks.size == 1
+  next if track.album.album_type == "single"
 
   # TODO: Consider skipping 'Live' and 'Remastered' albums
 


### PR DESCRIPTION
- Singles can have more than one track. The previous code was picking up things that the Spotify UI identified as "singles", but that had 2 or 3 tracks.

----

- Thanks for building this - I was looking at doing similar!
